### PR TITLE
Fix poor marker performance

### DIFF
--- a/__tests__/__snapshots__/building-highlights.test.js.snap
+++ b/__tests__/__snapshots__/building-highlights.test.js.snap
@@ -48,6 +48,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -141,6 +143,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -210,6 +214,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -375,6 +381,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -656,6 +664,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -749,6 +759,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -830,6 +842,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -963,6 +977,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1044,6 +1060,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1113,6 +1131,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1174,6 +1194,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1243,6 +1265,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1352,6 +1376,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1413,6 +1439,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1474,6 +1502,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1535,6 +1565,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1600,6 +1632,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1661,6 +1695,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1722,6 +1758,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1783,6 +1821,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1844,6 +1884,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1905,6 +1947,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -1974,6 +2018,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2043,6 +2089,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2104,6 +2152,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2165,6 +2215,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2226,6 +2278,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2299,6 +2353,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2464,6 +2520,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2525,6 +2583,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2682,6 +2742,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -2787,6 +2849,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3012,6 +3076,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3113,6 +3179,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3190,6 +3258,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3251,6 +3321,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3336,6 +3408,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3469,6 +3543,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3530,6 +3606,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3591,6 +3669,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -3920,6 +4000,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4089,6 +4171,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4262,6 +4346,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4355,6 +4441,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4432,6 +4520,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4657,6 +4747,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4691,6 +4783,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4752,6 +4846,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4813,6 +4909,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4874,6 +4972,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -4947,6 +5047,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5040,6 +5142,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5109,6 +5213,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5178,6 +5284,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5255,6 +5363,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5316,6 +5426,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5417,6 +5529,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5478,6 +5592,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5595,6 +5711,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5629,6 +5747,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5690,6 +5810,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5751,6 +5873,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5852,6 +5976,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={
@@ -5929,6 +6055,8 @@ exports[`Building Highlight Snapshop renders correctly 1`] = `
           undefined,
         ]
       }
+      tracksInfoWindowChanges={false}
+      tracksViewChanges={false}
     >
       <Text
         style={

--- a/src/components/building-highlights/building-highlights.component.tsx
+++ b/src/components/building-highlights/building-highlights.component.tsx
@@ -48,6 +48,8 @@ const BuildingHighlights = ({ onBuildingTap, tappedBuilding }: IProps) => {
             onPress={() => {
               onBuildingTap(building.id);
             }}
+            tracksViewChanges={false}
+            tracksInfoWindowChanges={false}
           >
             <Text style={styles.marker}>{BuildingId[building.id]}</Text>
           </Marker>


### PR DESCRIPTION
After merging the latest PR, many have noticed increased latency and power usage by the application. The root cause was traced back to markers. When disabling them, the performance issues went away. After some research on the official [react-native-maps documentation](https://github.com/react-native-community/react-native-maps/blob/master/docs/marker.md), some props for markers need to be set to false to disable unnecessary computations.

Before applying these optimizations, the JS performance was pretty poor (40 cycles a second and many dropped frames):
![slow](https://user-images.githubusercontent.com/23544999/76709013-cce55100-66d1-11ea-8df2-516312f98e64.png)

After applying these optimizations, the JS performance was much improved (almost 60 cycles a second):
![fast](https://user-images.githubusercontent.com/23544999/76709034-e8505c00-66d1-11ea-8284-7b7442b8cfb9.png)


