### PR TITLE
HOTFIX: Disable toolbar on google maps

### DIFF
--- a/src/screens/map-screen/map-screen.component.tsx
+++ b/src/screens/map-screen/map-screen.component.tsx
@@ -273,6 +273,7 @@ const MapScreen = () => {
           // @ts-ignore
           onIndoorBuildingFocused={event => onIndoorViewEntry(event)}
           showsIndoorLevelPicker={false}
+          toolbarEnabled={false}
         >
           <MapOverlays
             onBuildingTap={onBuildingTap}


### PR DESCRIPTION
This pr aims to disable the toolbar on google maps (the two buttons visible at the bottom right in this screenshot).

This is not a feature we want or need in our application, and it remained hidden behind the campus toggle since early development.

![image](https://user-images.githubusercontent.com/23544999/78408631-a8e0a580-75d5-11ea-9b7c-fef0470f4e1d.png)
