### PR TITLE
TASK-24: Fix floor picker before indoor view

### DIFF
--- a/e2e/user-story-11.spec.ts
+++ b/e2e/user-story-11.spec.ts
@@ -17,7 +17,7 @@ const setLocation = async (latitude, longitude) => {
   exec(`idb set-location --udid ${device._deviceId} ${latitude} ${longitude}`);
 };
 
-describe("US-14: Indoor Points of Interest", () => {
+describe("US-11: Search Start and Destination Room", () => {
   it("should bring up autocomplete POI list in search mode for both start and destination locations with location services off", async () => {
     // @ts-ignore
     await element(by.id("mapView")).pinchWithAngle("outward", "slow", 0);

--- a/src/components/floor-picker/floor-picker.component.tsx
+++ b/src/components/floor-picker/floor-picker.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet } from "react-native";
 import { TouchableOpacity } from "react-native-gesture-handler";
-import { IndoorInformation, TravelState } from "../../types/main";
+import { IndoorInformation, TravelState, ZoomLevel } from "../../types/main";
 import {
   FLOOR_PICKER_HEIGHT,
   FLOOR_PICKER_TRAVEL_HEIGHT,
@@ -15,6 +15,7 @@ interface IProps {
   indoorInformation: IndoorInformation;
   onFloorPickerButtonPress: (index: number) => void;
   travelState: TravelState;
+  zoomLevel: ZoomLevel;
 }
 
 /**
@@ -26,12 +27,14 @@ interface IProps {
 const FloorPicker = ({
   indoorInformation,
   onFloorPickerButtonPress,
-  travelState
+  travelState,
+  zoomLevel
 }: IProps) => {
   return (
     <>
       {indoorInformation.floors.length > 0 &&
-      indoorInformation.currentFloor !== null ? (
+      indoorInformation.currentFloor !== null &&
+      zoomLevel === ZoomLevel.INDOOR ? (
         <View
           style={StyleSheet.flatten([
             styles.container,

--- a/src/screens/map-screen/map-screen.component.tsx
+++ b/src/screens/map-screen/map-screen.component.tsx
@@ -299,6 +299,7 @@ const MapScreen = () => {
           indoorInformation={indoorInformation}
           onFloorPickerButtonPress={onFloorPickerButtonPress}
           travelState={travelState}
+          zoomLevel={zoomLevel}
         />
 
         <BuildingInformation


### PR DESCRIPTION
This pr aims to fix a display bug where the floor picker would show up before the indoor view would show up. 

Now the floor picker will only show up on the same zoom level as the pois.

This pr addresses the following issue: #90