### PR TITLE
US-13: Accessible indoor navigation

### DIFF
--- a/__tests__/__testData__/pathfinding.data.ts
+++ b/__tests__/__testData__/pathfinding.data.ts
@@ -350,23 +350,11 @@ export const brokenGraph: TravelNode[] = [
 export const h96117toMBMensBathroom = [
   {
     buildingId: "H",
-    connectorType: 4,
+    connectorType: 8,
     level: 9,
     path: [
       [
-        { latitude: 45.497314, longitude: -73.578751 },
-        { latitude: 45.497223, longitude: -73.578861 },
-      ],
-      [
-        { latitude: 45.497223, longitude: -73.578861 },
-        { latitude: 45.497322, longitude: -73.579066 },
-      ],
-      [
-        { latitude: 45.497322, longitude: -73.579066 },
-        { latitude: 45.49739, longitude: -73.579014 },
-      ],
-      [
-        { latitude: 45.49739, longitude: -73.579014 },
+        { latitude: 45.497438, longitude: -73.578964 },
         { latitude: 45.497563, longitude: -73.578837 },
       ],
       [
@@ -377,11 +365,11 @@ export const h96117toMBMensBathroom = [
   },
   {
     buildingId: "H",
-    connectorType: 4,
+    connectorType: 8,
     level: 8,
     path: [
       [
-        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497354, longitude: -73.578713 },
         { latitude: 45.497314, longitude: -73.578751 },
       ],
     ],
@@ -483,6 +471,7 @@ export const h9117toH8WomensBathroom = [
     ],
   },
 ];
+
 export const h8WomensBathroomToH9117 = [
   {
     buildingId: "H",
@@ -565,7 +554,7 @@ export const h3rdFloorPoiMock = {
       children: [0],
     },
   ],
-  disableFriendly: [],
+  disabledFriendly: [],
 };
 
 export const accessibleH96117toPoliceStExit = [
@@ -646,23 +635,11 @@ export const accessibleH96117toPoliceStExit = [
 export const h96117toPoliceStExit = [
   {
     buildingId: "H",
-    connectorType: 4,
+    connectorType: 8,
     level: 9,
     path: [
       [
-        { latitude: 45.497314, longitude: -73.578751 },
-        { latitude: 45.497223, longitude: -73.578861 },
-      ],
-      [
-        { latitude: 45.497223, longitude: -73.578861 },
-        { latitude: 45.497322, longitude: -73.579066 },
-      ],
-      [
-        { latitude: 45.497322, longitude: -73.579066 },
-        { latitude: 45.49739, longitude: -73.579014 },
-      ],
-      [
-        { latitude: 45.49739, longitude: -73.579014 },
+        { latitude: 45.497438, longitude: -73.578964 },
         { latitude: 45.497563, longitude: -73.578837 },
       ],
       [
@@ -673,11 +650,11 @@ export const h96117toPoliceStExit = [
   },
   {
     buildingId: "H",
-    connectorType: 4,
+    connectorType: 8,
     level: 8,
     path: [
       [
-        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497354, longitude: -73.578713 },
         { latitude: 45.497314, longitude: -73.578751 },
       ],
     ],
@@ -713,6 +690,65 @@ export const h96117toPoliceStExit = [
       [
         { latitude: 45.49522388917384, longitude: -73.57863295823336 },
         { latitude: 45.495216991097614, longitude: -73.5785603480603 },
+      ],
+    ],
+  },
+];
+
+export const mbStairsToS1ToCC119 = [
+  {
+    buildingId: "CC",
+    level: 1,
+    path: [
+      [
+        { latitude: 45.458116, longitude: -73.639914 },
+        { latitude: 45.458161806440636, longitude: -73.63997407257557 },
+      ],
+      [
+        { latitude: 45.458161806440636, longitude: -73.63997407257557 },
+        { latitude: 45.45825399406411, longitude: -73.64020708948374 },
+      ],
+      [
+        { latitude: 45.45825399406411, longitude: -73.64020708948374 },
+        { latitude: 45.45836076219479, longitude: -73.64047598093748 },
+      ],
+      [
+        { latitude: 45.45836076219479, longitude: -73.64047598093748 },
+        { latitude: 45.458403, longitude: -73.640648 },
+      ],
+    ],
+  },
+  {
+    buildingId: "MB",
+    level: 1,
+    path: [
+      [
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.495291, longitude: -73.578866 },
+      ],
+      [
+        { latitude: 45.495291, longitude: -73.578866 },
+        { latitude: 45.495197, longitude: -73.578708 },
+      ],
+      [
+        { latitude: 45.495197, longitude: -73.578708 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495277037243376, longitude: -73.57859236859093 },
       ],
     ],
   },

--- a/__tests__/__testData__/pathfinding.data.ts
+++ b/__tests__/__testData__/pathfinding.data.ts
@@ -350,11 +350,31 @@ export const brokenGraph: TravelNode[] = [
 export const h96117toMBMensBathroom = [
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "37f6e5b8-0b86-4fed-9d3a-9f5e3a4231bd",
+      level: 9,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 9,
     path: [
       [
-        { latitude: 45.497438, longitude: -73.578964 },
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497223, longitude: -73.578861 },
+      ],
+      [
+        { latitude: 45.497223, longitude: -73.578861 },
+        { latitude: 45.497322, longitude: -73.579066 },
+      ],
+      [
+        { latitude: 45.497322, longitude: -73.579066 },
+        { latitude: 45.49739, longitude: -73.579014 },
+      ],
+      [
+        { latitude: 45.49739, longitude: -73.579014 },
         { latitude: 45.497563, longitude: -73.578837 },
       ],
       [
@@ -365,11 +385,19 @@ export const h96117toMBMensBathroom = [
   },
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "058086ab-58be-4174-a34d-d0dd7e80014f",
+      level: 8,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 8,
     path: [
       [
-        { latitude: 45.497354, longitude: -73.578713 },
+        { latitude: 45.497314, longitude: -73.578751 },
         { latitude: 45.497314, longitude: -73.578751 },
       ],
     ],
@@ -434,7 +462,15 @@ export const h96117toH9MensBathroom = [
 export const h9117toH8WomensBathroom = [
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 8,
+      description: "",
+      displayName: "Stairs 2",
+      id: "363649b3-61ea-4138-b8bb-b116412bcabb",
+      level: 9,
+      location: { latitude: 45.497438, longitude: -73.578964 },
+    },
     level: 9,
     path: [
       [
@@ -449,15 +485,23 @@ export const h9117toH8WomensBathroom = [
   },
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 8,
+      description: "",
+      displayName: "Stairs 2",
+      id: "c4541028-739d-4651-b9f5-dc4d54054807",
+      level: 8,
+      location: { latitude: 45.497482, longitude: -73.579034 },
+    },
     level: 8,
     path: [
       [
-        { latitude: 45.497354, longitude: -73.578713 },
-        { latitude: 45.49736449098771, longitude: -73.57873593028044 },
+        { latitude: 45.497482, longitude: -73.579034 },
+        { latitude: 45.49756354338001, longitude: -73.57899677510714 },
       ],
       [
-        { latitude: 45.49736449098771, longitude: -73.57873593028044 },
+        { latitude: 45.49756354338001, longitude: -73.57899677510714 },
         { latitude: 45.49741149279668, longitude: -73.57868966217494 },
       ],
       [
@@ -475,7 +519,15 @@ export const h9117toH8WomensBathroom = [
 export const h8WomensBathroomToH9117 = [
   {
     buildingId: "H",
-    connectorType: 6,
+    connector: {
+      buildingId: "H",
+      category: 6,
+      description: "",
+      displayName: "Escalators Up",
+      id: "07366816-4ca4-47b5-808f-ba034508bd10",
+      level: 8,
+      location: { latitude: 45.497267, longitude: -73.578869 },
+    },
     level: 8,
     path: [
       [
@@ -494,7 +546,15 @@ export const h8WomensBathroomToH9117 = [
   },
   {
     buildingId: "H",
-    connectorType: 6,
+    connector: {
+      buildingId: "H",
+      category: 6,
+      description: "",
+      displayName: "Escalators Up",
+      id: "f45af436-f9bb-40b8-97c5-8526ad68ac55",
+      level: 9,
+      location: { latitude: 45.497317, longitude: -73.57901 },
+    },
     level: 9,
     path: [
       [
@@ -560,7 +620,15 @@ export const h3rdFloorPoiMock = {
 export const accessibleH96117toPoliceStExit = [
   {
     buildingId: "H",
-    connectorType: 4,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "37f6e5b8-0b86-4fed-9d3a-9f5e3a4231bd",
+      level: 9,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 9,
     path: [
       [
@@ -587,7 +655,15 @@ export const accessibleH96117toPoliceStExit = [
   },
   {
     buildingId: "H",
-    connectorType: 4,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "058086ab-58be-4174-a34d-d0dd7e80014f",
+      level: 8,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 8,
     path: [
       [
@@ -635,11 +711,31 @@ export const accessibleH96117toPoliceStExit = [
 export const h96117toPoliceStExit = [
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "37f6e5b8-0b86-4fed-9d3a-9f5e3a4231bd",
+      level: 9,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 9,
     path: [
       [
-        { latitude: 45.497438, longitude: -73.578964 },
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497223, longitude: -73.578861 },
+      ],
+      [
+        { latitude: 45.497223, longitude: -73.578861 },
+        { latitude: 45.497322, longitude: -73.579066 },
+      ],
+      [
+        { latitude: 45.497322, longitude: -73.579066 },
+        { latitude: 45.49739, longitude: -73.579014 },
+      ],
+      [
+        { latitude: 45.49739, longitude: -73.579014 },
         { latitude: 45.497563, longitude: -73.578837 },
       ],
       [
@@ -650,11 +746,19 @@ export const h96117toPoliceStExit = [
   },
   {
     buildingId: "H",
-    connectorType: 8,
+    connector: {
+      buildingId: "H",
+      category: 4,
+      description: "",
+      displayName: "Elevator",
+      id: "058086ab-58be-4174-a34d-d0dd7e80014f",
+      level: 8,
+      location: { latitude: 45.497314, longitude: -73.578751 },
+    },
     level: 8,
     path: [
       [
-        { latitude: 45.497354, longitude: -73.578713 },
+        { latitude: 45.497314, longitude: -73.578751 },
         { latitude: 45.497314, longitude: -73.578751 },
       ],
     ],
@@ -677,14 +781,6 @@ export const h96117toPoliceStExit = [
       ],
       [
         { latitude: 45.495319, longitude: -73.578834 },
-        { latitude: 45.495319, longitude: -73.578834 },
-      ],
-      [
-        { latitude: 45.495319, longitude: -73.578834 },
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
-      ],
-      [
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
         { latitude: 45.49522388917384, longitude: -73.57863295823336 },
       ],
       [
@@ -695,7 +791,7 @@ export const h96117toPoliceStExit = [
   },
 ];
 
-export const mbStairsToS1ToCC119 = [
+export const accessibleMbStairsToS1ToCC119 = [
   {
     buildingId: "CC",
     level: 1,

--- a/__tests__/__testData__/pathfinding.data.ts
+++ b/__tests__/__testData__/pathfinding.data.ts
@@ -350,11 +350,11 @@ export const brokenGraph: TravelNode[] = [
 export const h96117toMBMensBathroom = [
   {
     buildingId: "H",
-    connectorType: 7,
+    connectorType: 4,
     level: 9,
     path: [
       [
-        { latitude: 45.497269, longitude: -73.578862 },
+        { latitude: 45.497314, longitude: -73.578751 },
         { latitude: 45.497223, longitude: -73.578861 },
       ],
       [
@@ -377,12 +377,12 @@ export const h96117toMBMensBathroom = [
   },
   {
     buildingId: "H",
-    connectorType: 7,
+    connectorType: 4,
     level: 8,
     path: [
       [
-        { latitude: 45.49731, longitude: -73.57901 },
-        { latitude: 45.49731, longitude: -73.57901 },
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497314, longitude: -73.578751 },
       ],
     ],
   },
@@ -567,3 +567,153 @@ export const h3rdFloorPoiMock = {
   ],
   disableFriendly: [],
 };
+
+export const accessibleH96117toPoliceStExit = [
+  {
+    buildingId: "H",
+    connectorType: 4,
+    level: 9,
+    path: [
+      [
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497223, longitude: -73.578861 },
+      ],
+      [
+        { latitude: 45.497223, longitude: -73.578861 },
+        { latitude: 45.497322, longitude: -73.579066 },
+      ],
+      [
+        { latitude: 45.497322, longitude: -73.579066 },
+        { latitude: 45.49739, longitude: -73.579014 },
+      ],
+      [
+        { latitude: 45.49739, longitude: -73.579014 },
+        { latitude: 45.497563, longitude: -73.578837 },
+      ],
+      [
+        { latitude: 45.497563, longitude: -73.578837 },
+        { latitude: 45.497643, longitude: -73.578983 },
+      ],
+    ],
+  },
+  {
+    buildingId: "H",
+    connectorType: 4,
+    level: 8,
+    path: [
+      [
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497314, longitude: -73.578751 },
+      ],
+    ],
+  },
+  {
+    buildingId: "MB",
+    level: 1,
+    path: [
+      [
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.495291, longitude: -73.578866 },
+      ],
+      [
+        { latitude: 45.495291, longitude: -73.578866 },
+        { latitude: 45.495197, longitude: -73.578708 },
+      ],
+      [
+        { latitude: 45.495197, longitude: -73.578708 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495216991097614, longitude: -73.5785603480603 },
+      ],
+    ],
+  },
+];
+
+export const h96117toPoliceStExit = [
+  {
+    buildingId: "H",
+    connectorType: 4,
+    level: 9,
+    path: [
+      [
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497223, longitude: -73.578861 },
+      ],
+      [
+        { latitude: 45.497223, longitude: -73.578861 },
+        { latitude: 45.497322, longitude: -73.579066 },
+      ],
+      [
+        { latitude: 45.497322, longitude: -73.579066 },
+        { latitude: 45.49739, longitude: -73.579014 },
+      ],
+      [
+        { latitude: 45.49739, longitude: -73.579014 },
+        { latitude: 45.497563, longitude: -73.578837 },
+      ],
+      [
+        { latitude: 45.497563, longitude: -73.578837 },
+        { latitude: 45.497643, longitude: -73.578983 },
+      ],
+    ],
+  },
+  {
+    buildingId: "H",
+    connectorType: 4,
+    level: 8,
+    path: [
+      [
+        { latitude: 45.497314, longitude: -73.578751 },
+        { latitude: 45.497314, longitude: -73.578751 },
+      ],
+    ],
+  },
+  {
+    buildingId: "MB",
+    level: 1,
+    path: [
+      [
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495216991097614, longitude: -73.5785603480603 },
+      ],
+    ],
+  },
+];

--- a/__tests__/__testData__/pathfinding.data.ts
+++ b/__tests__/__testData__/pathfinding.data.ts
@@ -1,8 +1,10 @@
 import {
   TravelNode,
   Line,
-  BuildingId,
   POICategory,
+  FloorPath,
+  POI,
+  BuildingFloor,
 } from "../../src/types/main";
 
 /**
@@ -347,7 +349,7 @@ export const brokenGraph: TravelNode[] = [
   },
 ];
 
-export const h96117toMBMensBathroom = [
+export const h96117toMBMensBathroom: FloorPath[] = [
   {
     buildingId: "H",
     connector: {
@@ -407,26 +409,26 @@ export const h96117toMBMensBathroom = [
     level: 1,
     path: [
       [
-        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
-        { latitude: 45.495498624635324, longitude: -73.57925221323967 },
-      ],
-      [
-        { latitude: 45.495498624635324, longitude: -73.57925221323967 },
-        { latitude: 45.495454035943894, longitude: -73.57927702759403 },
-      ],
-      [
-        { latitude: 45.495454035943894, longitude: -73.57927702759403 },
-        { latitude: 45.49538722650027, longitude: -73.57932228595018 },
-      ],
-      [
-        { latitude: 45.49538722650027, longitude: -73.57932228595018 },
         { latitude: 45.49533465172625, longitude: -73.57934289831273 },
+        { latitude: 45.49538722650027, longitude: -73.57932228595018 },
+      ],
+      [
+        { latitude: 45.49538722650027, longitude: -73.57932228595018 },
+        { latitude: 45.495454035943894, longitude: -73.57927702759403 },
+      ],
+      [
+        { latitude: 45.495454035943894, longitude: -73.57927702759403 },
+        { latitude: 45.495498624635324, longitude: -73.57925221323967 },
+      ],
+      [
+        { latitude: 45.495498624635324, longitude: -73.57925221323967 },
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
       ],
     ],
   },
 ];
 
-export const h96117toH9MensBathroom = [
+export const h96117toH9MensBathroom: FloorPath[] = [
   {
     buildingId: "H",
     level: 9,
@@ -459,7 +461,7 @@ export const h96117toH9MensBathroom = [
   },
 ];
 
-export const h9117toH8WomensBathroom = [
+export const h9117toH8WomensBathroom: FloorPath[] = [
   {
     buildingId: "H",
     connector: {
@@ -516,7 +518,7 @@ export const h9117toH8WomensBathroom = [
   },
 ];
 
-export const h8WomensBathroomToH9117 = [
+export const h8WomensBathroomToH9117: FloorPath[] = [
   {
     buildingId: "H",
     connector: {
@@ -577,7 +579,7 @@ export const h8WomensBathroomToH9117 = [
   },
 ];
 
-export const h3rdFloorMock = {
+export const h3rdPoiMock: POI = {
   id: "8dd47eee-23b4-437c-bd74-aad3876f83dc",
   displayName: "Stairs 1",
   description: "",
@@ -590,7 +592,7 @@ export const h3rdFloorMock = {
   category: POICategory.Stairs,
 };
 
-export const h3rdFloorPoiMock = {
+export const h3rdBuildingFloorMock: BuildingFloor = {
   id: 3,
   buildingId: "H",
   level: 3,
@@ -614,10 +616,10 @@ export const h3rdFloorPoiMock = {
       children: [0],
     },
   ],
-  disabledFriendly: [],
+  unfriendlyConnections: [],
 };
 
-export const accessibleH96117toPoliceStExit = [
+export const accessibleH96117toPoliceStExit: FloorPath[] = [
   {
     buildingId: "H",
     connector: {
@@ -677,38 +679,38 @@ export const accessibleH96117toPoliceStExit = [
     level: 1,
     path: [
       [
-        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-      ],
-      [
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-      ],
-      [
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-        { latitude: 45.495319, longitude: -73.578834 },
-      ],
-      [
-        { latitude: 45.495319, longitude: -73.578834 },
-        { latitude: 45.495291, longitude: -73.578866 },
-      ],
-      [
-        { latitude: 45.495291, longitude: -73.578866 },
-        { latitude: 45.495197, longitude: -73.578708 },
-      ],
-      [
-        { latitude: 45.495197, longitude: -73.578708 },
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
-      ],
-      [
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
         { latitude: 45.495216991097614, longitude: -73.5785603480603 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495197, longitude: -73.578708 },
+      ],
+      [
+        { latitude: 45.495197, longitude: -73.578708 },
+        { latitude: 45.495291, longitude: -73.578866 },
+      ],
+      [
+        { latitude: 45.495291, longitude: -73.578866 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
       ],
     ],
   },
 ];
 
-export const h96117toPoliceStExit = [
+export const h96117toPoliceStExit: FloorPath[] = [
   {
     buildingId: "H",
     connector: {
@@ -768,30 +770,30 @@ export const h96117toPoliceStExit = [
     level: 1,
     path: [
       [
-        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-      ],
-      [
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-      ],
-      [
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-        { latitude: 45.495319, longitude: -73.578834 },
-      ],
-      [
-        { latitude: 45.495319, longitude: -73.578834 },
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
-      ],
-      [
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
         { latitude: 45.495216991097614, longitude: -73.5785603480603 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
       ],
     ],
   },
 ];
 
-export const accessibleMbStairsToS1ToCC119 = [
+export const accessibleMbStairsToS1ToCC119: FloorPath[] = [
   {
     buildingId: "CC",
     level: 1,
@@ -819,32 +821,32 @@ export const accessibleMbStairsToS1ToCC119 = [
     level: 1,
     path: [
       [
-        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-      ],
-      [
-        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-      ],
-      [
-        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
-        { latitude: 45.495319, longitude: -73.578834 },
-      ],
-      [
-        { latitude: 45.495319, longitude: -73.578834 },
-        { latitude: 45.495291, longitude: -73.578866 },
-      ],
-      [
-        { latitude: 45.495291, longitude: -73.578866 },
-        { latitude: 45.495197, longitude: -73.578708 },
-      ],
-      [
-        { latitude: 45.495197, longitude: -73.578708 },
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
-      ],
-      [
-        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
         { latitude: 45.495277037243376, longitude: -73.57859236859093 },
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+      ],
+      [
+        { latitude: 45.49522388917384, longitude: -73.57863295823336 },
+        { latitude: 45.495197, longitude: -73.578708 },
+      ],
+      [
+        { latitude: 45.495197, longitude: -73.578708 },
+        { latitude: 45.495291, longitude: -73.578866 },
+      ],
+      [
+        { latitude: 45.495291, longitude: -73.578866 },
+        { latitude: 45.495319, longitude: -73.578834 },
+      ],
+      [
+        { latitude: 45.495319, longitude: -73.578834 },
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+      ],
+      [
+        { latitude: 45.49536913015795, longitude: -73.57889883220196 },
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+      ],
+      [
+        { latitude: 45.49536466482581, longitude: -73.57903562486172 },
+        { latitude: 45.49554740223838, longitude: -73.57927136202986 },
       ],
     ],
   },

--- a/__tests__/__testData__/pathfinding.data.ts
+++ b/__tests__/__testData__/pathfinding.data.ts
@@ -565,4 +565,5 @@ export const h3rdFloorPoiMock = {
       children: [0],
     },
   ],
+  disableFriendly: [],
 };

--- a/__tests__/pathfinding.service.test.js
+++ b/__tests__/pathfinding.service.test.js
@@ -14,10 +14,9 @@ describe("Find the shortest path between two locations/POI's", () => {
       (floor) => floor.buildingId === "H" && floor.level === 8
     );
     const shortest = findPathOnFloor(
-      travelNodes,
-      POIInfo.filter(({ displayName }) => displayName === "H851.03")[0]
-        .location,
-      POIInfo.filter(({ displayName }) => displayName === "H815")[0].location
+      POIInfo.filter(({ displayName }) => displayName === "H851.03")[0],
+      POIInfo.filter(({ displayName }) => displayName === "H815")[0],
+      false
     );
     expect(shortest).toEqual(testData.h85103toH815);
   });
@@ -27,24 +26,11 @@ describe("Find the shortest path between two locations/POI's", () => {
       (floor) => floor.buildingId === "H" && floor.level === 9
     );
     const shortest = findPathOnFloor(
-      travelNodes,
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0]
-        .location,
-      POIInfo.filter(({ displayName }) => displayName === "H911")[0].location
+      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
+      POIInfo.filter(({ displayName }) => displayName === "H911")[0],
+      false
     );
     expect(shortest).toEqual(testData.h96119toH911);
-  });
-
-  it("should return null when no path is found", () => {
-    const travelNodes = testData.brokenGraph;
-    const shortest = findPathOnFloor(
-      travelNodes,
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0]
-        .location,
-      POIInfo.filter(({ displayName }) => displayName === "H911")[0].location
-    );
-
-    expect(shortest).toBeNull();
   });
 
   it("should return one line only between two locations next to each other", () => {
@@ -52,9 +38,9 @@ describe("Find the shortest path between two locations/POI's", () => {
       (floor) => floor.buildingId === "H" && floor.level === 9
     );
     const shortest = findPathOnFloor(
-      travelNodes,
-      POIInfo.filter(({ displayName }) => displayName === "H923")[0].location,
-      POIInfo.filter(({ displayName }) => displayName === "H921")[0].location
+      POIInfo.filter(({ displayName }) => displayName === "H923")[0],
+      POIInfo.filter(({ displayName }) => displayName === "H921")[0],
+      false
     );
     expect(shortest.length).toBe(1);
     expect(shortest).toEqual(testData.h923toH921);
@@ -65,10 +51,9 @@ describe("Find the shortest path between two locations/POI's", () => {
       (floor) => floor.buildingId === "H" && floor.level === 9
     );
     const shortest = findPathOnFloor(
-      travelNodes,
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0]
-        .location,
-      POIInfo.filter(({ displayName }) => displayName === "H961-9")[0].location
+      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
+      POIInfo.filter(({ displayName }) => displayName === "H961-9")[0],
+      false
     );
     expect(shortest.length).toBe(1);
     expect(shortest).toEqual(testData.h96119toH9619);
@@ -82,7 +67,8 @@ describe("Find the shortest path between two locations/POI's", () => {
       POIInfo.find(({ displayName, level }) => displayName === "H961-17"),
       POIInfo.find(
         ({ displayName, level }) => displayName === "Stairs 1" && level === 3
-      )
+      ),
+      false
     );
 
     constants.buildingFloors.pop();
@@ -98,7 +84,8 @@ describe("Find the shortest path between two locations/POI's", () => {
       POIInfo.find(
         ({ buildingId, displayName, level }) =>
           buildingId === "MB" && displayName === "Men's Bathroom" && level === 1
-      )
+      ),
+      false
     );
     expect(path.length).toBe(3);
     expect(path).toEqual(testData.h96117toMBMensBathroom);
@@ -110,7 +97,8 @@ describe("Find the shortest path between two locations/POI's", () => {
       POIInfo.find(
         ({ displayName, level }) =>
           displayName === "Men's Bathroom" && level === 9
-      )
+      ),
+      false
     );
     expect(path.length).toBe(1);
     expect(path).toEqual(testData.h96117toH9MensBathroom);
@@ -122,7 +110,8 @@ describe("Find the shortest path between two locations/POI's", () => {
       POIInfo.find(
         ({ buildingId, displayName, level }) =>
           displayName === "Women's Bathroom" && level === 8
-      )
+      ),
+      false
     );
     expect(path.length).toBe(2);
     expect(path).toEqual(testData.h9117toH8WomensBathroom);
@@ -134,9 +123,23 @@ describe("Find the shortest path between two locations/POI's", () => {
         ({ buildingId, displayName, level }) =>
           displayName === "Women's Bathroom" && level === 8
       ),
-      POIInfo.find(({ displayName }) => displayName === "H961-17")
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
+      false
     );
     expect(path.length).toBe(2);
     expect(path).toEqual(testData.h8WomensBathroomToH9117);
+  });
+
+  it("should return null when no path is found", () => {
+    constants.buildingFloors.find(
+      (floor) => floor.buildingId === "H" && floor.level === 9
+    ).travelNodes = testData.brokenGraph;
+    const shortest = findPathOnFloor(
+      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
+      POIInfo.filter(({ displayName }) => displayName === "H911")[0],
+      false
+    );
+
+    expect(shortest).toBeNull();
   });
 });

--- a/__tests__/pathfinding.service.test.js
+++ b/__tests__/pathfinding.service.test.js
@@ -49,8 +49,10 @@ describe("Find the shortest path between two locations/POI's", () => {
   });
 
   it("should return a path that uses stairs as connectors", () => {
-    constants.buildingFloors = buildingFloors.push(testData.h3rdFloorPoiMock);
-    constants.POIInfo.push(testData.h3rdFloorMock);
+    constants.buildingFloors = buildingFloors.push(
+      testData.h3rdBuildingFloorMock
+    );
+    constants.POIInfo.push(testData.h3rdPoiMock);
 
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
@@ -146,7 +148,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     ).travelNodes = initialNodes;
   });
 
-  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB. Should take the ramp in MB.", () => {
+  it("should return the most accessible path between two given POI's in Hall and JMSB when accessibility mode is enabled. Should take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(
@@ -161,7 +163,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     expect(path).toEqual(testData.accessibleH96117toPoliceStExit);
   });
 
-  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in CC and MB. Should take the ramp in MB.", () => {
+  it("should return the most accessible path between two given POI's in CC and MB when accessibility mode is enabled. Should take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "CC119"),
       POIInfo.find(
@@ -174,7 +176,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     expect(path).toEqual(testData.accessibleMbStairsToS1ToCC119);
   });
 
-  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB. Should not take the ramp in MB.", () => {
+  it("should return the shortest path between two given POI's in Hall and JMSB when accessibility mode is disabled. Should not take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(

--- a/__tests__/pathfinding.service.test.js
+++ b/__tests__/pathfinding.service.test.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import * as testData from "./__testData__/pathfinding.data";
 import { POIInfo, buildingFloors } from "../src/constants";
 import * as constants from "../src/constants";
@@ -79,36 +80,6 @@ describe("Find the shortest path between two locations/POI's", () => {
     expect(path).toEqual(testData.h96117toMBMensBathroom);
   });
 
-  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB", () => {
-    const path = findPathBetweenPOIs(
-      POIInfo.find(({ displayName }) => displayName === "H961-17"),
-      POIInfo.find(
-        ({ buildingId, displayName, level }) =>
-          buildingId === "MB" &&
-          displayName === "Police St. Exit" &&
-          level === 1
-      ),
-      true
-    );
-    expect(path.length).toBe(3);
-    expect(path).toEqual(testData.accessibleH96117toPoliceStExit);
-  });
-
-  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB", () => {
-    const path = findPathBetweenPOIs(
-      POIInfo.find(({ displayName }) => displayName === "H961-17"),
-      POIInfo.find(
-        ({ buildingId, displayName, level }) =>
-          buildingId === "MB" &&
-          displayName === "Police St. Exit" &&
-          level === 1
-      ),
-      false
-    );
-    expect(path.length).toBe(3);
-    expect(path).toEqual(testData.h96117toPoliceStExit);
-  });
-
   it("should return the shortest path between two given POIs on H 9th floor", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
@@ -153,6 +124,12 @@ describe("Find the shortest path between two locations/POI's", () => {
   });
 
   it("should return null when no path is found", () => {
+    // store the initial nodes
+    const initialNodes = _.cloneDeep(
+      constants.buildingFloors.find(
+        (floor) => floor.buildingId === "H" && floor.level === 9
+      ).travelNodes
+    );
     constants.buildingFloors.find(
       (floor) => floor.buildingId === "H" && floor.level === 9
     ).travelNodes = testData.brokenGraph;
@@ -163,5 +140,52 @@ describe("Find the shortest path between two locations/POI's", () => {
     );
 
     expect(shortest).toBeNull();
+    // reset the initial nodes
+    constants.buildingFloors.find(
+      (floor) => floor.buildingId === "H" && floor.level === 9
+    ).travelNodes = initialNodes;
+  });
+
+  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB", () => {
+    const path = findPathBetweenPOIs(
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
+      POIInfo.find(
+        ({ buildingId, displayName, level }) =>
+          buildingId === "MB" &&
+          displayName === "Police St. Exit" &&
+          level === 1
+      ),
+      true
+    );
+    expect(path.length).toBe(3);
+    expect(path).toEqual(testData.accessibleH96117toPoliceStExit);
+  });
+
+  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in CC and MB", () => {
+    const path = findPathBetweenPOIs(
+      POIInfo.find(({ displayName }) => displayName === "CC119"),
+      POIInfo.find(
+        ({ buildingId, displayName, level }) =>
+          buildingId === "MB" && displayName === "Stairs to S1" && level === 1
+      ),
+      true
+    );
+    expect(path.length).toBe(2);
+    expect(path).toEqual(testData.mbStairsToS1ToCC119);
+  });
+
+  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB", () => {
+    const path = findPathBetweenPOIs(
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
+      POIInfo.find(
+        ({ buildingId, displayName, level }) =>
+          buildingId === "MB" &&
+          displayName === "Police St. Exit" &&
+          level === 1
+      ),
+      false
+    );
+    expect(path.length).toBe(3);
+    expect(path).toEqual(testData.h96117toPoliceStExit);
   });
 });

--- a/__tests__/pathfinding.service.test.js
+++ b/__tests__/pathfinding.service.test.js
@@ -63,8 +63,8 @@ describe("Find the shortest path between two locations/POI's", () => {
     constants.buildingFloors.pop();
     constants.POIInfo.pop();
 
-    expect(path[0].connectorType).toEqual(POICategory.Stairs);
-    expect(path[1].connectorType).toEqual(POICategory.Stairs);
+    expect(path[0].connector.category).toEqual(POICategory.Stairs);
+    expect(path[1].connector.category).toEqual(POICategory.Stairs);
   });
 
   it("should return the shortest path between two given POI's in Hall and JMSB", () => {
@@ -146,7 +146,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     ).travelNodes = initialNodes;
   });
 
-  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB", () => {
+  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB. Should take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(
@@ -161,7 +161,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     expect(path).toEqual(testData.accessibleH96117toPoliceStExit);
   });
 
-  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in CC and MB", () => {
+  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in CC and MB. Should take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "CC119"),
       POIInfo.find(
@@ -171,10 +171,10 @@ describe("Find the shortest path between two locations/POI's", () => {
       true
     );
     expect(path.length).toBe(2);
-    expect(path).toEqual(testData.mbStairsToS1ToCC119);
+    expect(path).toEqual(testData.accessibleMbStairsToS1ToCC119);
   });
 
-  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB", () => {
+  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB. Should not take the ramp in MB.", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(

--- a/__tests__/pathfinding.service.test.js
+++ b/__tests__/pathfinding.service.test.js
@@ -10,36 +10,27 @@ describe("Find the shortest path between two locations/POI's", () => {
     findPathBetweenPOIs,
   } = PathFindingService.getInstance();
   it("should return the shortest path between two given locations on H 8th floor", () => {
-    const { travelNodes } = buildingFloors.find(
-      (floor) => floor.buildingId === "H" && floor.level === 8
-    );
     const shortest = findPathOnFloor(
-      POIInfo.filter(({ displayName }) => displayName === "H851.03")[0],
-      POIInfo.filter(({ displayName }) => displayName === "H815")[0],
+      POIInfo.find(({ displayName }) => displayName === "H851.03"),
+      POIInfo.find(({ displayName }) => displayName === "H815"),
       false
     );
     expect(shortest).toEqual(testData.h85103toH815);
   });
 
   it("should return the shortest path between two given locations on H 9th floor", () => {
-    const { travelNodes } = buildingFloors.find(
-      (floor) => floor.buildingId === "H" && floor.level === 9
-    );
     const shortest = findPathOnFloor(
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
-      POIInfo.filter(({ displayName }) => displayName === "H911")[0],
+      POIInfo.find(({ displayName }) => displayName === "H961-19"),
+      POIInfo.find(({ displayName }) => displayName === "H911"),
       false
     );
     expect(shortest).toEqual(testData.h96119toH911);
   });
 
   it("should return one line only between two locations next to each other", () => {
-    const { travelNodes } = buildingFloors.find(
-      (floor) => floor.buildingId === "H" && floor.level === 9
-    );
     const shortest = findPathOnFloor(
-      POIInfo.filter(({ displayName }) => displayName === "H923")[0],
-      POIInfo.filter(({ displayName }) => displayName === "H921")[0],
+      POIInfo.find(({ displayName }) => displayName === "H923"),
+      POIInfo.find(({ displayName }) => displayName === "H921"),
       false
     );
     expect(shortest.length).toBe(1);
@@ -47,12 +38,9 @@ describe("Find the shortest path between two locations/POI's", () => {
   });
 
   it("should return one line only between two locations near the edges of a line", () => {
-    const { travelNodes } = buildingFloors.find(
-      (floor) => floor.buildingId === "H" && floor.level === 9
-    );
     const shortest = findPathOnFloor(
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
-      POIInfo.filter(({ displayName }) => displayName === "H961-9")[0],
+      POIInfo.find(({ displayName }) => displayName === "H961-19"),
+      POIInfo.find(({ displayName }) => displayName === "H961-9"),
       false
     );
     expect(shortest.length).toBe(1);
@@ -64,7 +52,7 @@ describe("Find the shortest path between two locations/POI's", () => {
     constants.POIInfo.push(testData.h3rdFloorMock);
 
     const path = findPathBetweenPOIs(
-      POIInfo.find(({ displayName, level }) => displayName === "H961-17"),
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(
         ({ displayName, level }) => displayName === "Stairs 1" && level === 3
       ),
@@ -91,12 +79,42 @@ describe("Find the shortest path between two locations/POI's", () => {
     expect(path).toEqual(testData.h96117toMBMensBathroom);
   });
 
+  it("when accessibility mode is enabled, should return the most accessible path between two given POI's in Hall and JMSB", () => {
+    const path = findPathBetweenPOIs(
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
+      POIInfo.find(
+        ({ buildingId, displayName, level }) =>
+          buildingId === "MB" &&
+          displayName === "Police St. Exit" &&
+          level === 1
+      ),
+      true
+    );
+    expect(path.length).toBe(3);
+    expect(path).toEqual(testData.accessibleH96117toPoliceStExit);
+  });
+
+  it("when accessibility mode is disabled, should return the shortest path between two given POI's in Hall and JMSB", () => {
+    const path = findPathBetweenPOIs(
+      POIInfo.find(({ displayName }) => displayName === "H961-17"),
+      POIInfo.find(
+        ({ buildingId, displayName, level }) =>
+          buildingId === "MB" &&
+          displayName === "Police St. Exit" &&
+          level === 1
+      ),
+      false
+    );
+    expect(path.length).toBe(3);
+    expect(path).toEqual(testData.h96117toPoliceStExit);
+  });
+
   it("should return the shortest path between two given POIs on H 9th floor", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(
-        ({ displayName, level }) =>
-          displayName === "Men's Bathroom" && level === 9
+        ({ displayName, level, buildingId }) =>
+          displayName === "Men's Bathroom" && level === 9 && buildingId === "H"
       ),
       false
     );
@@ -109,7 +127,9 @@ describe("Find the shortest path between two locations/POI's", () => {
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       POIInfo.find(
         ({ buildingId, displayName, level }) =>
-          displayName === "Women's Bathroom" && level === 8
+          displayName === "Women's Bathroom" &&
+          level === 8 &&
+          buildingId === "H"
       ),
       false
     );
@@ -121,7 +141,9 @@ describe("Find the shortest path between two locations/POI's", () => {
     const path = findPathBetweenPOIs(
       POIInfo.find(
         ({ buildingId, displayName, level }) =>
-          displayName === "Women's Bathroom" && level === 8
+          displayName === "Women's Bathroom" &&
+          level === 8 &&
+          buildingId === "H"
       ),
       POIInfo.find(({ displayName }) => displayName === "H961-17"),
       false
@@ -135,8 +157,8 @@ describe("Find the shortest path between two locations/POI's", () => {
       (floor) => floor.buildingId === "H" && floor.level === 9
     ).travelNodes = testData.brokenGraph;
     const shortest = findPathOnFloor(
-      POIInfo.filter(({ displayName }) => displayName === "H961-19")[0],
-      POIInfo.filter(({ displayName }) => displayName === "H911")[0],
+      POIInfo.find(({ displayName }) => displayName === "H961-19"),
+      POIInfo.find(({ displayName }) => displayName === "H911"),
       false
     );
 

--- a/src/components/map-overlays/travel-node-debug.component.tsx
+++ b/src/components/map-overlays/travel-node-debug.component.tsx
@@ -9,22 +9,30 @@ interface IProps {
 }
 
 const TravelNodeDebug = ({ id }: IProps) => {
+  const floorPaths = [];
+  let lines = [];
+  floorPaths.forEach((floorPath) => {
+    lines = lines.concat(floorPath.path);
+  });
   return (
     <>
-      {buildingFloors
-        .filter((buildingFloor) => buildingFloor.id === id)
-        .map((buildingFloor) => (
+      {lines.map((line, index) => (
+        <Polyline key={index} coordinates={line} />
+      ))}
+      {/* {buildingFloors
+        .filter(buildingFloor => buildingFloor.id === id)
+        .map(buildingFloor => (
           <>
             {PathFindingService.getInstance()
               .traverseNodes(buildingFloor.travelNodes)
-              .map((line) => (
+              .map(line => (
                 <>
-                  <Polyline coordinates={line.map((edge) => edge.location)} />
+                  <Polyline coordinates={line.map(edge => edge.location)} />
                 </>
               ))}
             {PathFindingService.getInstance()
               .traverseNodes(buildingFloor.travelNodes)
-              .map((line) => (
+              .map(line => (
                 <>
                   <Marker coordinate={line[0].location}>
                     <Text>{line[0].id}</Text>
@@ -35,7 +43,7 @@ const TravelNodeDebug = ({ id }: IProps) => {
                 </>
               ))}
           </>
-        ))}
+        ))} */}
     </>
   );
 };

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -155,6 +155,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
+    disableUnfriendly: [],
   },
   {
     id: 2,
@@ -316,6 +317,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
+    disableUnfriendly: [],
   },
   {
     id: 3,
@@ -423,7 +425,32 @@ export const buildingFloors: BuildingFloor[] = [
         },
         children: [1, 2],
       },
+      {
+        id: 12,
+        location: {
+          latitude: 45.495291,
+          longitude: -73.578866,
+        },
+        children: [6, 7, 13],
+      },
+      {
+        id: 13,
+        location: {
+          latitude: 45.495319,
+          longitude: -73.578834,
+        },
+        children: [12, 14],
+      },
+      {
+        id: 14,
+        location: {
+          latitude: 45.495197,
+          longitude: -73.578708,
+        },
+        children: [7, 10, 13],
+      },
     ],
+    disableUnfriendly: [[7, 12]],
   },
   {
     id: 4,
@@ -476,5 +503,6 @@ export const buildingFloors: BuildingFloor[] = [
         children: [3],
       },
     ],
+    disableUnfriendly: [],
   },
 ];

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -155,7 +155,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableFriendly: [],
+    disableUnfriendly: [],
   },
   {
     id: 2,
@@ -317,7 +317,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableFriendly: [],
+    disableUnfriendly: [],
   },
   {
     id: 3,
@@ -383,7 +383,7 @@ export const buildingFloors: BuildingFloor[] = [
           latitude: 45.49536913015795,
           longitude: -73.57889883220196,
         },
-        children: [3, 7],
+        children: [3, 12],
       },
       {
         id: 7,
@@ -391,7 +391,7 @@ export const buildingFloors: BuildingFloor[] = [
           latitude: 45.49522388917384,
           longitude: -73.57863295823336,
         },
-        children: [6, 8, 9, 10],
+        children: [8, 9, 14, 16],
       },
       {
         id: 8,
@@ -428,16 +428,16 @@ export const buildingFloors: BuildingFloor[] = [
       {
         id: 12,
         location: {
-          latitude: 45.495291,
-          longitude: -73.578866,
+          latitude: 45.495319,
+          longitude: -73.578834,
         },
-        children: [6, 7, 13],
+        children: [6, 13, 15],
       },
       {
         id: 13,
         location: {
-          latitude: 45.495319,
-          longitude: -73.578834,
+          latitude: 45.495291,
+          longitude: -73.578866,
         },
         children: [12, 14],
       },
@@ -449,8 +449,25 @@ export const buildingFloors: BuildingFloor[] = [
         },
         children: [7, 10, 13],
       },
+      {
+        id: 15,
+        location: {
+          latitude: 45.495319,
+          longitude: -73.578834,
+        },
+
+        children: [12, 16],
+      },
+      {
+        id: 16,
+        location: {
+          latitude: 45.49522388917384,
+          longitude: -73.57863295823336,
+        },
+        children: [7, 15],
+      },
     ],
-    disableFriendly: [13],
+    disableUnfriendly: [15, 16],
   },
   {
     id: 4,
@@ -503,6 +520,6 @@ export const buildingFloors: BuildingFloor[] = [
         children: [3],
       },
     ],
-    disableFriendly: [],
+    disableUnfriendly: [],
   },
 ];

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -155,7 +155,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableUnfriendly: [],
+    disableFriendly: [],
   },
   {
     id: 2,
@@ -317,7 +317,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableUnfriendly: [],
+    disableFriendly: [],
   },
   {
     id: 3,
@@ -450,7 +450,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [7, 10, 13],
       },
     ],
-    disableUnfriendly: [[7, 12]],
+    disableFriendly: [13],
   },
   {
     id: 4,
@@ -503,6 +503,6 @@ export const buildingFloors: BuildingFloor[] = [
         children: [3],
       },
     ],
-    disableUnfriendly: [],
+    disableFriendly: [],
   },
 ];

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -155,7 +155,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableUnfriendly: [],
+    disabledUnfriendly: [],
   },
   {
     id: 2,
@@ -317,7 +317,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disableUnfriendly: [],
+    disabledUnfriendly: [],
   },
   {
     id: 3,
@@ -467,7 +467,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [7, 15],
       },
     ],
-    disableUnfriendly: [15, 16],
+    disabledUnfriendly: [15, 16],
   },
   {
     id: 4,
@@ -520,6 +520,6 @@ export const buildingFloors: BuildingFloor[] = [
         children: [3],
       },
     ],
-    disableUnfriendly: [],
+    disabledUnfriendly: [],
   },
 ];

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -155,7 +155,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disabledUnfriendly: [],
+    unfriendlyConnections: [],
   },
   {
     id: 2,
@@ -317,7 +317,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [17],
       },
     ],
-    disabledUnfriendly: [],
+    unfriendlyConnections: [],
   },
   {
     id: 3,
@@ -450,7 +450,7 @@ export const buildingFloors: BuildingFloor[] = [
         children: [7, 10, 13],
       },
     ],
-    disabledUnfriendly: [7, 12],
+    unfriendlyConnections: [7, 12],
   },
   {
     id: 4,
@@ -503,6 +503,6 @@ export const buildingFloors: BuildingFloor[] = [
         children: [3],
       },
     ],
-    disabledUnfriendly: [],
+    unfriendlyConnections: [],
   },
 ];

--- a/src/constants/floors.data.ts
+++ b/src/constants/floors.data.ts
@@ -391,7 +391,7 @@ export const buildingFloors: BuildingFloor[] = [
           latitude: 45.49522388917384,
           longitude: -73.57863295823336,
         },
-        children: [8, 9, 14, 16],
+        children: [8, 9, 12, 14],
       },
       {
         id: 8,
@@ -431,7 +431,7 @@ export const buildingFloors: BuildingFloor[] = [
           latitude: 45.495319,
           longitude: -73.578834,
         },
-        children: [6, 13, 15],
+        children: [6, 7, 13],
       },
       {
         id: 13,
@@ -449,25 +449,8 @@ export const buildingFloors: BuildingFloor[] = [
         },
         children: [7, 10, 13],
       },
-      {
-        id: 15,
-        location: {
-          latitude: 45.495319,
-          longitude: -73.578834,
-        },
-
-        children: [12, 16],
-      },
-      {
-        id: 16,
-        location: {
-          latitude: 45.49522388917384,
-          longitude: -73.57863295823336,
-        },
-        children: [7, 15],
-      },
     ],
-    disabledUnfriendly: [15, 16],
+    disabledUnfriendly: [7, 12],
   },
   {
     id: 4,

--- a/src/constants/poi.data.ts
+++ b/src/constants/poi.data.ts
@@ -106,8 +106,8 @@ export const POIInfo: POI[] = [
     displayName: "Exit",
     description: "",
     location: {
-      latitude: 45.49731,
-      longitude: -73.57901,
+      latitude: 45.497314,
+      longitude: -73.578751,
     },
     buildingId: "H",
     level: 8,

--- a/src/services/pathfinding.service.ts
+++ b/src/services/pathfinding.service.ts
@@ -307,13 +307,13 @@ class PathFindingService {
     );
 
     if (accessibilityMode) {
-      const { disableUnfriendly } = buildingFloors.find(
+      const { disabledUnfriendly } = buildingFloors.find(
         (floor) =>
           floor.buildingId === start.buildingId && floor.level === start.level
       );
-      disableUnfriendly.forEach((nodeId) => {
+      disabledUnfriendly.forEach((nodeId) => {
         nodes[nodeId].children = nodes[nodeId].children.filter(
-          (c) => !disableUnfriendly.includes(c)
+          (child) => !disabledUnfriendly.includes(child)
         );
       });
     }

--- a/src/services/pathfinding.service.ts
+++ b/src/services/pathfinding.service.ts
@@ -33,7 +33,7 @@ class PathFindingService {
    *
    * @param start The start POI
    * @param end The end POI
-   *
+   * @param accessibilityMode a boolean indicating if the accessibility mode is enabled
    * @returns The list of paths to travese between the start and end POI's
    */
   public findPathBetweenPOIs = (
@@ -54,28 +54,29 @@ class PathFindingService {
       accessibilityMode
     );
     const endBuildingPath = this.findBuildingPath(
-      end,
       endBuildingExit,
+      end,
       accessibilityMode
     );
     return startBuildingPath.concat(endBuildingPath);
   };
 
   /**
-   * Finds the exit of a building
+   * Finds a POI by category and buidingId
    *
-   * @param start The start POI
+   * @param categorization the category of POI
+   * @param building the id of the buiding
    *
-   * @Returns the exit of a building
+   * @Returns the POI that satisfies the category and buildingId constraints
    */
   private findPOI = (
     categorization: POICategory,
     building: BuildingId
-  ): ConnectorPOI => {
+  ): POI => {
     return POIInfo.find(
       ({ category, buildingId }) =>
         category === categorization && buildingId === building
-    ) as ConnectorPOI;
+    );
   };
 
   /**
@@ -83,7 +84,7 @@ class PathFindingService {
    *
    * @param start The start POI
    * @param end The end POI
-   *
+   * @param accessibilityMode a boolean indicating if the accessibility mode is enabled
    * @returns The list of paths to travese between the start and end POI's
    */
   private findBuildingPath = (
@@ -101,7 +102,7 @@ class PathFindingService {
       ];
     }
 
-    let POIcategories;
+    let POIcategories: POICategory[];
     if (accessibilityMode) {
       POIcategories = [POICategory.Elevator];
     } else {
@@ -146,7 +147,7 @@ class PathFindingService {
    * Returns all connector POI's which are in the same floor and building as the given POI.
    *
    * @param poi POI whose building/floor is searched for conenctors
-   * @param escalatorDirection Accepted escalator direction for current travel plan
+   * @param POICategories the categories of connector POI
    *
    * @returns A list of connectorPOI's
    */
@@ -184,7 +185,7 @@ class PathFindingService {
    * @param poi POI which serves as the start point for per-floor navigation
    * @param connectors List of reachable connectors. These POI's must be on the
    * same building/floor as the starting POI
-   *
+   * @param accessibilityMode a boolean indicating if the accessibility mode is enabled
    * @returns List of valid paths
    */
   private getPathsBetweenPOIAndConnectors = (
@@ -261,14 +262,14 @@ class PathFindingService {
   };
 
   /**
-   * Find the shortest path between two locations on a given floor.
+   * Find the shortest path between two POI's on a given floor.
    * Returns an array of lines if the path is found.
    * Returns null if no path is found.
    *
-   * @param start start location
-   * @param end end location
-   *
-   * @returns A list of TravelEdges
+   * @param start start POI
+   * @param end end POI
+   * @param accessibilityMode a boolean indicating if the accessibility mode is enabled
+   * @returns A list of Line or null
    */
   public findPathOnFloor = (
     start: POI,
@@ -323,13 +324,13 @@ class PathFindingService {
     );
 
     if (accessibilityMode) {
-      const { disabledUnfriendly } = buildingFloors.find(
+      const { unfriendlyConnections } = buildingFloors.find(
         (floor) =>
           floor.buildingId === start.buildingId && floor.level === start.level
       );
-      disabledUnfriendly.forEach((nodeId) => {
+      unfriendlyConnections.forEach((nodeId) => {
         nodes[nodeId].children = nodes[nodeId].children.filter(
-          (child) => !disabledUnfriendly.includes(child)
+          (child) => !unfriendlyConnections.includes(child)
         );
       });
     }

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -72,6 +72,7 @@ export interface BuildingFloor {
   bounds: [Coordinate, Coordinate] | null;
   image: any;
   travelNodes: TravelNode[];
+  disableUnfriendly: number[][]
 }
 
 export interface TravelNode {

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -100,7 +100,7 @@ export type FloorPath = {
   buildingId: BuildingId;
   level: number;
   path: Line[];
-  connectorType?: ConnectorPOICategory;
+  connector?: POI;
 };
 
 export type ConnectorPOICategory =

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -72,7 +72,7 @@ export interface BuildingFloor {
   bounds: [Coordinate, Coordinate] | null;
   image: any;
   travelNodes: TravelNode[];
-  disabledUnfriendly: number[];
+  unfriendlyConnections: number[];
 }
 
 export interface TravelNode {

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -72,7 +72,7 @@ export interface BuildingFloor {
   bounds: [Coordinate, Coordinate] | null;
   image: any;
   travelNodes: TravelNode[];
-  disableUnfriendly: number[][]
+  disableFriendly: number[];
 }
 
 export interface TravelNode {

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -72,7 +72,7 @@ export interface BuildingFloor {
   bounds: [Coordinate, Coordinate] | null;
   image: any;
   travelNodes: TravelNode[];
-  disableFriendly: number[];
+  disableUnfriendly: number[];
 }
 
 export interface TravelNode {

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -72,7 +72,7 @@ export interface BuildingFloor {
   bounds: [Coordinate, Coordinate] | null;
   image: any;
   travelNodes: TravelNode[];
-  disableUnfriendly: number[];
+  disabledUnfriendly: number[];
 }
 
 export interface TravelNode {


### PR DESCRIPTION
This PR implements issue #44 

#### When accessibilityMode equals true:
- Only elevators will be selected as a connector between floors
- The node connections that are not disabled-friendly will be broken. For example, in the first image, the connection between node 7 and node 12 will be broken.
- New nodes were added in MB for the ramp (12, 13, and 14).

![image](https://user-images.githubusercontent.com/36641869/79076743-84b65000-7cca-11ea-84b1-df5c04c163ae.png)



#### For the same inputs:
- Takes the ramp when accessibilityMode equals true (the most accessible but not shortest path):
![image](https://user-images.githubusercontent.com/36641869/79076962-c5629900-7ccb-11ea-9536-942829b7d4bb.png)

- Takes the same-floor stairs when accessibilityMode equals false (the shortest path):
![image](https://user-images.githubusercontent.com/36641869/79076978-e7f4b200-7ccb-11ea-81b0-09d962b2ad8a.png)
