### PR TITLE
TASK 27: Match Jest and SonarCloud code coverage 

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,18 +18,22 @@ module.exports = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: null,
+  collectCoverageFrom: [
+    "<rootDir>/src/components/*/*.tsx",
+    "<rootDir>/src/services/*.ts",
+  ],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/src/services/location.service.ts",
+    "<rootDir>/src/services/firebase.service.ts",
+  ],
 
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [


### PR DESCRIPTION
This PR implements TASK-27 (#106).
The files analyzed for code coverage in both Jest and SonarCloud is the same. 

* For Jest, run `npm run test`
* For SonarCloud, check this link https://sonarcloud.io/component_measures?id=RGPosadas_WayFinder&metric=coverage&view=list

There should be a total of 16 files analyzed; 13 under `src/components` and 3 under `src/services`